### PR TITLE
Multiple servers and memcached sessions

### DIFF
--- a/index.php
+++ b/index.php
@@ -88,7 +88,7 @@ class Simple_memchached_dashboard{
     }
 
     function is_logged_in(){
-		return (isset($_SESSION['username']) && $_SESSION['username'] != '');
+		return (isset($_SESSION['username']) && isset($this->users[$_SESSION['username']]) && $_SESSION['username'] != '');
 	}
 
 	function add_user($user_name,$user_pass){
@@ -97,8 +97,8 @@ class Simple_memchached_dashboard{
 
 	function logout(){
 		if(isset($_GET['action']) && $_GET['action'] == 'logout') {
-			$_SESSION['username'] = '';
-			session_destroy();
+			unset($_SESSION['username']);
+			session_write_close();
 			header('Location:  ' . $_SERVER['PHP_SELF']);
 		}
 	}

--- a/index.php
+++ b/index.php
@@ -88,7 +88,7 @@ class Simple_memchached_dashboard{
     }
 
     function is_logged_in(){
-		return (isset($_SESSION['username']) && isset($this->users[$_SESSION['username']]) && $_SESSION['username'] != '');
+		return (isset($_SESSION['memcached_dashboard_username']) && isset($this->users[$_SESSION['memcached_dashboard_username']]) && $_SESSION['memcached_dashboard_username'] != '');
 	}
 
 	function add_user($user_name,$user_pass){
@@ -97,7 +97,7 @@ class Simple_memchached_dashboard{
 
 	function logout(){
 		if(isset($_GET['action']) && $_GET['action'] == 'logout') {
-			unset($_SESSION['username']);
+			unset($_SESSION['memcached_dashboard_username']);
 			session_write_close();
 			header('Location:  ' . $_SERVER['PHP_SELF']);
 		}
@@ -110,7 +110,7 @@ class Simple_memchached_dashboard{
 			$pass = $_POST['password'];
 			if ($this->user_exists($user)){
 				if($pass == $this->get_user_pass($user)) {
-					$_SESSION['username'] = $_POST['username'];
+					$_SESSION['memcached_dashboard_username'] = $_POST['username'];
 				}else {
 					$this->error = 'Wrong Password!';
 				}

--- a/index.php
+++ b/index.php
@@ -587,4 +587,4 @@ class Simple_memchached_dashboard{
 		<?php
 	}
 }//end class
-new Simple_memchached_dashboard($servers, $users);
+new Simple_memchached_dashboard();


### PR DESCRIPTION
Added ability to use multiple servers.  Multiple servers can come from php.ini if Memcached sessions are available by using the string 'session.save_path'.

Also fixed some potential session collisions when using memcached sessions and other software wich uses the $_SESSSION['username'] session variable.  Improved security by checking username is in usernames array.
